### PR TITLE
feat: Add Homebrew distribution via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,62 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: wakafetch
+    main: .
+    binary: wakafetch
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+changelog:
+  use: git
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+
+homebrew_casks:
+  - name: wakafetch
+    repository:
+      owner: sahaj-b
+      name: homebrew-wakafetch
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Casks
+    homepage: https://github.com/sahaj-b/wakafetch
+    description: "WakaTime activity fetcher CLI"
+    license: MIT
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/wakafetch"]
+          end

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ A command-line tool to fetch and display your coding stats from WakaTime or Waka
 
 ## 🚀 Installation
 
+### With Homebrew (macOS/Linux)
+
+```bash
+brew tap sahaj-b/wakafetch
+brew install wakafetch
+```
+
 ### With Nix Flake
 
 <details>


### PR DESCRIPTION
## Why This PR?

I wanted to install wakafetch via Homebrew, but there was no tap available. Rather than just creating my own tap, I thought it would be better to contribute the release automation back upstream so all users can benefit.

This PR adds **automated Homebrew distribution** for wakafetch. Once set up, pushing a version tag will automatically:
1. Build binaries for macOS and Linux (amd64 + arm64)
2. Create a GitHub Release with archives and checksums
3. Publish a Homebrew cask to your tap repository

Users will then be able to install with:
```bash
brew tap sahaj-b/wakafetch
brew install wakafetch
```

## What's Included

| File | Purpose |
|------|---------|
| `.goreleaser.yaml` | GoReleaser v2 config for multi-platform builds |
| `.github/workflows/release.yml` | GitHub Actions workflow triggered by version tags |
| `README.md` | Added Homebrew installation instructions |

## What You Need To Do

### 1. Create the tap repository

Create a new public repository: `sahaj-b/homebrew-wakafetch`

Initialize it with a simple README:
```markdown
# homebrew-wakafetch

Homebrew tap for [wakafetch](https://github.com/sahaj-b/wakafetch).

## Installation

\`\`\`bash
brew tap sahaj-b/wakafetch
brew install wakafetch
\`\`\`
```

And create an empty `Casks/` directory (GoReleaser will populate it).

### 2. Create a Personal Access Token

1. Go to https://github.com/settings/personal-access-tokens/new
2. Create a **Fine-grained token** with:
   - **Repository access**: Only select `sahaj-b/homebrew-wakafetch`
   - **Permissions**: Contents → Read and write
3. Set expiration (1 year recommended)
4. Copy the token value

### 3. Add the secret to this repository

1. Go to https://github.com/sahaj-b/wakafetch/settings/secrets/actions
2. Click "New repository secret"
3. Name: `HOMEBREW_TAP_TOKEN`
4. Value: (paste your PAT)

### 4. Create a release

```bash
git tag v0.1.0  # or whatever version you want
git push origin v0.1.0
```

The workflow will automatically:
- Build all platform binaries
- Create the GitHub Release
- Push the Homebrew cask to your tap

## Technical Details

- **GoReleaser v2** syntax (future-proof for v3)
- **CGO_ENABLED=0** for fully static binaries
- **macOS quarantine removal** via post-install hook (prevents Gatekeeper warnings)
- **Version injection** via ldflags (`-X main.version={{.Version}}`)

## Already Tested

I've tested this entire flow on my fork (b00y0h/wakafetch → b00y0h/homebrew-wakafetch) and confirmed:
- Tag triggers workflow
- All platform builds succeed
- Homebrew cask is published
- `brew tap && brew install` works
- Binary runs without macOS security warnings

Happy to answer any questions!